### PR TITLE
Compatibility of hwloc with the install command

### DIFF
--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -114,13 +114,14 @@ else()
       set(EXE_DIRECTORY_PATH "${CMAKE_BINARY_DIR}/$<CONFIG>/bin/")
     endif()
 
+    set(DLL_PATH "${HWLOC_ROOT}/bin/libhwloc-15.dll")
     add_custom_target(
       HwlocDLL ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory ${EXE_DIRECTORY_PATH}
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
-              "${HWLOC_ROOT}/bin/libhwloc-15.dll" ${EXE_DIRECTORY_PATH}
+              ${DLL_PATH} ${EXE_DIRECTORY_PATH}
     )
-    install(FILES "${HWLOC_ROOT}/bin/libhwloc-15.dll" DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES ${DLL_PATH} DESTINATION ${CMAKE_INSTALL_BINDIR})
     add_hpx_pseudo_target(HwlocDLL)
   endif()
 

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -120,6 +120,9 @@ else()
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
               "${HWLOC_ROOT}/bin/libhwloc-15.dll" ${EXE_DIRECTORY_PATH}
     )
+    install(FILES "${HWLOC_ROOT}/bin/libhwloc-15.dll" DESTINATION ${CMAKE_INSTALL_BINDIR})
     add_hpx_pseudo_target(HwlocDLL)
   endif()
+
+
 endif()


### PR DESCRIPTION
Now using install copies not only the hpx library dll files, but also the hwloc library dll file exactly to the exe file. Therefore, install will no longer fail.